### PR TITLE
[udpxy] Update

### DIFF
--- a/meta-openvision/recipes-openvision/udpxy/udpxy.bb
+++ b/meta-openvision/recipes-openvision/udpxy/udpxy.bb
@@ -3,7 +3,7 @@ MAINTAINER = "Pavel V. Cherenkov"
 SECTION = "multimedia"
 PRIORITY = "optional"
 LICENSE = "GPLv3"
-LIC_FILES_CHKSUM = "file://README;md5=b0c7b851d6d40e5194e73ca66db0e257"
+LIC_FILES_CHKSUM = "file://README;md5=f210c6f38d8c7db12fdfd009dcd9438c"
 
 inherit gitpkgv
 

--- a/meta-openvision/recipes-openvision/udpxy/udpxy/fix-build-with-gcc8.patch
+++ b/meta-openvision/recipes-openvision/udpxy/udpxy/fix-build-with-gcc8.patch
@@ -26,3 +26,16 @@ index c58ceb5..eb186f3 100644
                                          Zasctime(localtime( &g_recopt.end_time )),
                                          sizeof(sel_buf) );
  
+diff --git a/rparse.c b/rparse.c
+index 8cbdda5..a25832d 100644
+--- a/rparse.c
++++ b/rparse.c
+@@ -175,7 +175,7 @@ parse_udprelay( const char*  opt, size_t optlen,
+ 
+     assert( opt && s_addr && s_addrlen && addr && addrlen && port );
+ 
+-    (void) strncpy( s, opt, MAX_OPTLEN );
++    (void) memcpy( s, opt, MAX_OPTLEN );
+     s[ MAX_OPTLEN - 1 ] = '\0';
+ 
+     do {


### PR DESCRIPTION
*Update README md5
> ERROR: udpxy-1+gitAUTOINC+061a0ababc-r0 do_populate_lic: QA Issue: udpxy: The LIC_FILES_CHKSUM does not match for file://README;md5=b0c7b851d6d40e5194e73ca66db0e257
udpxy: The new md5 checksum is f210c6f38d8c7db12fdfd009dcd9438c
udpxy: Here is the selected license text:

*Fix compile error
> | rparse.c:178:12: error: 'strncpy' specified bound 512 equals destination size [-Werror=stringop-truncation]
|   178 |     (void) strncpy( s, opt, MAX_OPTLEN );
|       |            ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~